### PR TITLE
Use journal_mode=OFF

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -113,7 +113,9 @@ async.eachSeries(
 
         new mbtiles(outputPath, function(err, tiles) {
           if (err) throw err;
-          merge(tiles, inputTiles, verbose, maxzoom);
+          tiles._db.run('PRAGMA journal_mode=OFF', function(){
+            merge(tiles, inputTiles, verbose, maxzoom);
+          });
         });
       }
     );


### PR DESCRIPTION
In a test with 2 inputs, and about 400k tiles this led to a 10% speedup.